### PR TITLE
Remove outdated events

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,7 @@ With Substrate, you get the following *customizable- functionalities out-of-the-
 
 ### Events
 Substrate talks near you:
-- (Apr 29): Oslo Blockchain Day
-- (May 6-8): Re:publica in Berlin ft. Jutta Steiner. [Link](https://re-publica.com/en)
-- (May 9 -10): The next web in Amsterdam. [Link](https://thenextweb.com/conference/)
-- (May 10-11): Ethereal Summit in NYC. [Link]( https://etherealsummit.com/events/ethereal-ny/)
-- (May 13-15): Coindesk Consensus in NYC. [Link](https://www.coindesk.com/events/consensus-2019)
-- (May 13-15): Webit Festival in Bulgaria. [Link](https://www.webit.org/festival/2019/index.php)
-- (May 17-19): Eth New York, Eth Global Hackathon. [Link](https://twitter.com/ethnewyork)
-- (May 23-24): Malta AI & Blockchain Summit in Malta. [Link](https://maltablockchainsummit.com/)
-- (May 31): Crypto Chicks in Toronto. [Link](https://www.toronto.cryptochicks.ca/)
+
 Join the [Meetup Group](https://www.meetup.com/parity/events/) for more events.
 
 **Featured: Web3Summit tickets [are here](https://web3summit.com/). Coming Aug 19-21 '19.**


### PR DESCRIPTION
This is a bare minimum removal of outdated events. We should do one of the following

1. Add in upcoming events.
2. Entirely remove the events section.