### PR TITLE
Awesome substrate package manager sup

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,4 +163,4 @@ open-source library of [Rust](https://www.rust-lang.org/) code that is maintaine
   and libraries for debugging Substrate-based chains, including
   [`offline-election`](https://github.com/paritytech/substrate-debug-kit/tree/master/offline-election),
   which is a tool that is used to predict nominated proof-of-stake elections.
-- [sup](https://github.com/clearloop/sup) - Command line tool for generating or upgrading substrate node.
+- [`sup`](https://github.com/clearloop/sup) - Command line tool for generating or upgrading a Substrate node.

--- a/README.md
+++ b/README.md
@@ -163,3 +163,4 @@ open-source library of [Rust](https://www.rust-lang.org/) code that is maintaine
   and libraries for debugging Substrate-based chains, including
   [`offline-election`](https://github.com/paritytech/substrate-debug-kit/tree/master/offline-election),
   which is a tool that is used to predict nominated proof-of-stake elections.
+- [sup](https://github.com/clearloop/sup) - Command line tool for generating or upgrading substrate node.


### PR DESCRIPTION
## Sup

`sup` is a package manager for substrate, which can init a node-template or upgrade it via one command, `cargo install sup` before you want to try it~

```
sup 0.1.8

USAGE:
    sup <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    help       Prints this message or the help of the given subcommand(s)
    new        Create a new substrate node template
    source     List Source
    tag        List available tags
    update     Update registry
    upgrade    Upgrade substrate project
```