### PR TITLE
Privhost, public .onion tor nodes for the community

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ maintained by [Parity Technologies](https://www.parity.io/). Source code availab
 ## Products and Services
 
 - [OnFinality](https://onfinality.io) - Free and paid services to shared Substrate based nodes.
+- [PrivHost](https://privhost.laissez-faire.trade/) -  Public Tor .onion supported nodes for Polkadot, Kusama and Edgeware.     
 
 ## Alternative Implementations
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ maintained by [Parity Technologies](https://www.parity.io/). Source code availab
 ## Products and Services
 
 - [OnFinality](https://onfinality.io) - Free and paid services to shared Substrate based nodes.
-- [PrivHost](https://privhost.laissez-faire.trade/) -  Public Tor .onion supported nodes for Polkadot, Kusama and Edgeware.     
+- [PrivHost](https://privhost.laissez-faire.trade/) - Public Tor .onion supported nodes for Polkadot, Kusama and Edgeware.     
 
 ## Alternative Implementations
 


### PR DESCRIPTION
Privhost is a new project that provides public .onion nodes for the Polkadot ecosystem