### PR TITLE
add uptest as a tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ maintained by [Parity Technologies](https://www.parity.io/). Source code availab
 - [Polkaholic.io](https://polkaholic.io) - Multi-chain block explorer with API and DeFi support across 40+ parachains.
 - [SubID](https://github.com/dappforce/subid) - An advanced cross-chain portfolio management tool for the Polkadot ecosystem, allowing any user to see their balances across chains; view their crowdloan history; view their NFTs across Polkadot ecosystem chains; claim their vested tokens and perform cross-chain transfers.
 - [Subsocial SDK Playground](https://play.subsocial.network) - Subsocial JS SDK Playground allows you to fetch spaces, send transactions on blockchain and test the SDK code snippets on the go without the need to download or setup anything locally.
+- [Uptest Runtime upgrade tool](https://github.com/uptest-sc/uptest) - Uptest command line client and libuptest Rust library are two tools used for debugging storage changes and runtime upgrades.   
 
 ## Products and Services
 


### PR DESCRIPTION
Uptest(command line client) and Libuptest(core library) have now been delivered the first milestone which goes under the release name: v0.1.1 . Uptest goal is to make it easier for developers to debug runtime upgrades.   