### PR TITLE
Remove paritytech/parity-scale-codec-ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,6 @@ maintained by [Parity Technologies](https://www.parity.io/). Source code availab
 - [Ruby](https://github.com/itering/scale.rb) - Maintained by Itering.
 - [Scales](https://github.com/virto-network/scales) - Serializing SCALE using type information from a type registry.
 - JavaScript / TypeScript implementations:
-  - [paritytech/parity-scale-codec-ts](https://github.com/paritytech/parity-scale-codec-ts) - Maintained by Parity Technologies.
   - [polkadot-js/api](https://github.com/polkadot-js/api/tree/master/packages/types) - Maintained by Polkadot-JS.
   - [scale-ts](https://github.com/unstoppablejs/unstoppablejs/tree/main/packages/scale-ts#scale-ts) - Maintained by Josep M Sobrepere.
   - [soramitsu/scale-codec-js-library](https://github.com/soramitsu/scale-codec-js-library) - Maintained by Soramitsu.


### PR DESCRIPTION
Remove paritytech/parity-scale-codec-ts - Maintained by Parity Technologies. Link goes to a private repo of former employee T6